### PR TITLE
Update 2013-11-16-web-api-rest-with-symfony2-the-best-way-the-post-metho...

### DIFF
--- a/_posts/2013-11-16-web-api-rest-with-symfony2-the-best-way-the-post-method.md
+++ b/_posts/2013-11-16-web-api-rest-with-symfony2-the-best-way-the-post-method.md
@@ -402,7 +402,7 @@ The postPageAction is simple, all the domain logic is demanded to the `PageHandl
      *
      * @return FormTypeInterface|View
      */
-    public function postPageAction(Request $request)
+    public function postPagesAction(Request $request)
     {
        try {
            // Hey Page handler create a new Page.


### PR DESCRIPTION
...d.md

PostPages need to be in plural

Like FOSRestBundle describes:
post - this action accepts POST requests to the url /resources and creates a new resource of this type. Shown as UsersController::postUsersAction()
